### PR TITLE
Add Git Safeguards to Prevent Large PRs and Accidental Data Commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,9 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore.cursor/
+
+# Historical data and generated files
+data/historical/**/*.json
+data/historical/*.json
+data/*_analysis_*.json
+data/proposal_validation_*.json

--- a/docs/git_best_practices.md
+++ b/docs/git_best_practices.md
@@ -1,0 +1,115 @@
+# Git Best Practices for Governance Token Distribution Analyzer
+
+## Key Principles
+
+1. **Keep PRs Small and Focused**
+   - Target less than 400-500 lines of changes per PR
+   - Focus on a single feature, bug fix, or improvement
+   - Split large changes into multiple logical PRs
+
+2. **Avoid Committing Generated Files**
+   - Always check what you're committing with `git status` before making a commit
+   - Use `.gitignore` to exclude generated data files
+   - When in doubt, stage files individually rather than using `git add .`
+
+3. **Work on Feature Branches**
+   - Never make changes directly on `main`
+   - Create descriptive branch names: `feature/name`, `bugfix/name`, `refactor/name`
+   - Pull from `main` frequently to avoid large merge conflicts
+
+## Common Pitfalls to Avoid
+
+### Large PRs
+- Problem: Large PRs are difficult to review, prone to issues, and more likely to cause merge conflicts
+- Prevention: Break work into smaller, logical chunks and create multiple PRs
+- Fix: If a PR becomes too large, consider closing it and creating smaller ones
+
+### Committing Generated Files
+- Problem: Generated files create noise in the repository and bloat its size
+- Prevention: Keep `.gitignore` updated as new generated file types appear
+- Fix: Use `git rm --cached <file>` to remove files from tracking without deleting them
+
+### Force Pushing
+- Problem: Force pushing can overwrite history and cause issues for collaborators
+- Prevention: Only force push to your own feature branches before they're merged
+- Fix: When needed, communicate with the team before force pushing
+
+## Workflow Recommendations
+
+1. **Start of Day**
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b feature/my-new-feature
+   ```
+
+2. **During Development**
+   ```bash
+   # Commit small changes frequently
+   git add <specific-files>
+   git commit -m "[Component] Brief description"
+   
+   # Stay in sync with main
+   git checkout main
+   git pull
+   git checkout feature/my-new-feature
+   git merge main
+   ```
+
+3. **Before Creating a PR**
+   ```bash
+   # Check status and diff
+   git status
+   git diff --stat
+   
+   # Review what you're about to commit
+   git add <specific-files>
+   git diff --cached
+   
+   # Commit with a clear message
+   git commit -m "[Component] Concise description of changes"
+   ```
+
+## Tools to Help
+
+1. **Git Hooks**
+   - Use pre-commit hooks to prevent committing large files or files matching patterns in `.gitignore`
+   - Consider adding hooks to run linters and tests before pushing
+
+2. **Git Config**
+   - Set up your git identity:
+     ```bash
+     git config --global user.name "Your Name"
+     git config --global user.email "your.email@example.com"
+     ```
+
+3. **Git Aliases**
+   - Create helpful aliases for common commands:
+     ```bash
+     git config --global alias.st status
+     git config --global alias.co checkout
+     git config --global alias.br branch
+     git config --global alias.unstage 'reset HEAD --'
+     ```
+
+## Repository-specific Guidelines
+
+1. **Historical Data Files**
+   - All files in `data/historical/` should never be committed
+   - Files matching `data/*_analysis_*.json` should never be committed
+   - Files matching `data/proposal_validation_*.json` should never be committed
+
+2. **Test Generated Files**
+   - Never commit test-generated data files
+   - Check the test output directories before committing
+
+## Emergency Process for Fixing Large PRs
+
+If you find yourself with an excessively large PR that includes files that shouldn't be committed:
+
+1. Update `.gitignore` to prevent future occurrences
+2. Run `scripts/cleanup_git_history.sh` to untrack unwanted files
+3. Commit the changes to `.gitignore`
+4. Consider splitting the remaining legitimate changes into smaller PRs
+
+Remember: **Smaller PRs = Happier Reviewers = Faster Merges = Better Code** 

--- a/scripts/cleanup_git_history.sh
+++ b/scripts/cleanup_git_history.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Script to clean up historical data files from Git tracking
+
+# Ensure we're in the project root
+cd "$(git rev-parse --show-toplevel)"
+
+# Remove historical data files from Git tracking but keep locally
+git rm --cached -r data/historical/ 2>/dev/null || true
+git rm --cached data/*_analysis_*.json 2>/dev/null || true
+git rm --cached data/proposal_validation_*.json 2>/dev/null || true
+
+echo "Historical data files are now untracked. They still exist locally but won't be committed."
+echo "To verify, run 'git status' and check that the files are no longer listed as tracked."
+echo ""
+echo "NOTE: If you need to commit changes to these files in the future,"
+echo "you may need to modify the .gitignore file and use 'git add -f' to force-add them." 

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Script to install git hooks
+
+# Ensure we're in the project root
+cd "$(git rev-parse --show-toplevel)"
+
+# Create hooks directory if it doesn't exist
+mkdir -p .git/hooks
+
+# Create pre-commit hook
+cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/bash
+
+# Check for large files (>1MB)
+large_files=$(git diff --cached --name-only | xargs -I{} find {} -type f -size +1M 2>/dev/null)
+if [ -n "$large_files" ]; then
+  echo "ERROR: Attempting to commit the following large files (>1MB):"
+  echo "$large_files"
+  echo "Please reconsider if these files should be committed."
+  echo "To bypass this check, use git commit --no-verify"
+  exit 1
+fi
+
+# Check for historical data files
+historical_files=$(git diff --cached --name-only | grep -E "data/historical/|data/.*_analysis_.*\.json|data/proposal_validation_.*\.json")
+if [ -n "$historical_files" ]; then
+  echo "WARNING: Attempting to commit historical/generated data files:"
+  echo "$historical_files"
+  echo "These files should typically NOT be committed."
+  echo "If you're sure this is correct, use git commit --no-verify"
+  exit 1
+fi
+
+# Count the number of lines being changed
+lines_changed=$(git diff --cached --stat | tail -n 1 | cut -d' ' -f5)
+if [ -n "$lines_changed" ] && [ "$lines_changed" -gt 500 ]; then
+  echo "WARNING: You are committing $lines_changed lines of code."
+  echo "Consider breaking this into smaller, more focused commits."
+  echo "To bypass this check, use git commit --no-verify"
+  # Exit with warning but allow commit (change to exit 1 to block)
+  echo "Press Ctrl+C to cancel or Enter to proceed anyway..."
+  read -r
+fi
+
+# All checks passed
+exit 0
+EOF
+
+# Make pre-commit hook executable
+chmod +x .git/hooks/pre-commit
+
+# Create pre-push hook
+cat > .git/hooks/pre-push << 'EOF'
+#!/bin/bash
+
+# Get the current branch
+current_branch=$(git symbolic-ref --short HEAD)
+
+# Block direct pushes to main
+if [ "$current_branch" = "main" ]; then
+  echo "ERROR: Direct pushing to main branch is not allowed."
+  echo "Please create a feature branch and submit a pull request instead."
+  exit 1
+fi
+
+# Count total lines being pushed
+lines_changed=$(git diff --stat origin/$current_branch | tail -n 1 | cut -d' ' -f5)
+if [ -n "$lines_changed" ] && [ "$lines_changed" -gt 1000 ]; then
+  echo "WARNING: You are pushing $lines_changed lines of code."
+  echo "This is a large change that may be difficult to review."
+  echo "Consider breaking it into smaller, more focused changes."
+  echo "To bypass this check, use git push --no-verify"
+  # Exit with warning but allow push (change to exit 1 to block)
+  echo "Press Ctrl+C to cancel or Enter to proceed anyway..."
+  read -r
+fi
+
+# All checks passed
+exit 0
+EOF
+
+# Make pre-push hook executable
+chmod +x .git/hooks/pre-push
+
+echo "Git hooks installed successfully:"
+echo "- pre-commit hook: checks for large files and historical data files"
+echo "- pre-push hook: prevents direct pushing to main and warns about large changes"
+echo ""
+echo "To bypass these hooks when needed, use --no-verify flag:"
+echo "  git commit --no-verify"
+echo "  git push --no-verify" 


### PR DESCRIPTION
## Problem

Previously, we encountered large PRs (+32,663 −2,238 lines) containing historical data files that shouldn't be committed. These files bloat the repository size, make reviews difficult, and slow down cloning and operations.

## Solution

This PR adds several safeguards to prevent similar issues:

1. **Updated `.gitignore`** to exclude:
   - Historical data files in `data/historical/`
   - Analysis data files matching `data/*_analysis_*.json`
   - Proposal validation files matching `data/proposal_validation_*.json`

2. **Added Git hooks** via `scripts/install_git_hooks.sh`:
   - Pre-commit hook that blocks:
     - Large files (>1MB)
     - Historical/generated data files
     - Warns about large changes (>500 lines)
   - Pre-push hook that:
     - Prevents direct pushing to main
     - Warns about large pushes (>1000 lines)

3. **Added cleanup script** at `scripts/cleanup_git_history.sh` to:
   - Remove historical data files from git tracking while keeping them locally
   - Handle any existing data files that were accidentally committed

4. **Added documentation** in `docs/git_best_practices.md` covering:
   - PR size and focus guidelines
   - How to avoid committing generated files
   - Branch management best practices
   - Emergency process for fixing large PRs

## How to Use

After checking out this PR, run:

```bash
./scripts/install_git_hooks.sh
```

This will install the hooks that help prevent these issues in your local environment.

## Benefits

- **Cleaner repository**: Only source code, not generated data
- **Faster reviews**: PRs remain focused and manageable
- **Better history**: Meaningful commits without noise
- **Clearer contribution guidelines**: New contributors understand best practices

## Note

This PR replaces the previous PR that accidentally included large historical data files.