### PR TITLE
Fix Formatting Issues in Report Generator

### DIFF
--- a/src/governance_token_analyzer/visualization/report_generator.py
+++ b/src/governance_token_analyzer/visualization/report_generator.py
@@ -726,6 +726,19 @@ class ReportGenerator:
                 }
             )
 
+        # Format holders count and total supply safely
+        holders_count = report_data.get("holders_count", "N/A")
+        if isinstance(holders_count, (int, float)):
+            holders_display = f"{holders_count:,g}"
+        else:
+            holders_display = str(holders_count)
+        
+        total_supply = report_data.get("total_supply", "N/A")
+        if isinstance(total_supply, (int, float)):
+            supply_display = f"{total_supply:,.2f} tokens"
+        else:
+            supply_display = str(total_supply)
+
         # Create basic HTML report
         html_content = f"""
         <!DOCTYPE html>
@@ -752,8 +765,8 @@ class ReportGenerator:
             <div class="header">
                 <h1>🏛️ {protocol_name.upper()} Governance Token Analysis</h1>
                 <p><strong>Generated:</strong> {timestamp}</p>
-                <p><strong>Total Holders:</strong> {report_data.get("holders_count", "N/A"):,}</p>
-                <p><strong>Total Supply:</strong> {report_data.get("total_supply", "N/A"):,.2f} tokens</p>
+                <p><strong>Total Holders:</strong> {holders_display}</p>
+                <p><strong>Total Supply:</strong> {supply_display}</p>
             </div>
 
             <div class="protocol-info">

--- a/src/governance_token_analyzer/visualization/report_generator.py
+++ b/src/governance_token_analyzer/visualization/report_generator.py
@@ -732,7 +732,7 @@ class ReportGenerator:
             holders_display = f"{holders_count:,g}"
         else:
             holders_display = str(holders_count)
-        
+
         total_supply = report_data.get("total_supply", "N/A")
         if isinstance(total_supply, (int, float)):
             supply_display = f"{total_supply:,.2f} tokens"


### PR DESCRIPTION
## Problem
The report generator was failing with a `ValueError` when trying to format non-numeric values with numeric format specifiers. Specifically, when `holders_count` or `total_supply` were missing from `report_data`, the `.get()` method would return the default string "N/A", but then numeric format specifiers (`:,` and `:,.2f`) would be applied to these strings.

## Solution
This PR fixes the issue by:

1. **Extracting and preprocessing values** before inserting them into the HTML template
2. **Adding type checking** to ensure numeric formatting is only applied to actual numeric values
3. **Applying conditional formatting** based on the data type
4. **Simplifying the template code** by using pre-formatted display variables

## Changes
- Added preprocessing for `holders_count` and `total_supply` values
- Added type checking with `isinstance(value, (int, float))` 
- Created display variables that handle both numeric and non-numeric cases
- Simplified the HTML template by using these preprocessed values

## Testing
Verified that the report generator now properly handles cases where:
- Values are numeric (formats correctly with separators/decimals)
- Values are missing (displays "N/A" without formatting errors)
- Values are explicitly set to non-numeric types (displays without errors)

## Related Issues
Resolves the ValueErrors that occurred when generating reports with missing data.

## Summary by Sourcery

Fix formatting errors in the HTML report generator by preprocessing and conditionally formatting holders_count and total_supply values, and updating the report template to use the new display variables.

Bug Fixes:
- Safely handle missing or non-numeric holders_count and total_supply to avoid formatting errors

Enhancements:
- Extract and pre-format holders_count and total_supply into display variables for simplified template insertion