### PR TITLE
Fix Codecov Token Parameter Format in CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ commands:
     steps:
       - codecov/upload:
           file: << parameters.coverage_file >>
-          token: ${CODECOV_TOKEN}
+          token: CODECOV_TOKEN
           flags: << parameters.flags >>
           upload_name: ${CIRCLE_BUILD_NUM}
           when: always


### PR DESCRIPTION
## Problem
The CircleCI pipeline was failing with the following error:
Error calling workflow: 'build-test-deploy'
Error calling job: 'unit-tests-python-38'
Error calling command: 'upload_codecov'
Error calling command: 'codecov/upload'
Type error for argument token: expected type: env_var_name, actual value: "${CODECOV_TOKEN}" (type string)



## Root Cause
The `codecov/upload` command expects the `token` parameter to be an environment variable name (type: `env_var_name`), but it was being passed as a string with interpolation syntax (`${CODECOV_TOKEN}`).

## Solution
Modified the CircleCI config to pass the token parameter as a direct environment variable name without string interpolation:

```yaml
# Before
- codecov/upload:
    file: << parameters.coverage_file >>
    token: "${CODECOV_TOKEN}"
    flags: << parameters.flags >>
    upload_name: ${CIRCLE_BUILD_NUM}
    when: always

# After
- codecov/upload:
    file: << parameters.coverage_file >>
    token: CODECOV_TOKEN
    flags: << parameters.flags >>
    upload_name: ${CIRCLE_BUILD_NUM}
    when: always
```

## Testing
- Pushed the changes to trigger a new CircleCI pipeline run
- Verified the `codecov/upload` command now executes without errors

## References
- [CircleCI Orbs Best Practices](https://circleci.com/docs/orbs-best-practices/) - Documentation on handling secrets and environment variables
- [Codecov Orb Documentation](https://circleci.com/developer/orbs/orb/codecov/codecov) - Official documentation for the Codecov orb

## Summary by Sourcery

CI:
- Update codecov/upload step to use CODECOV_TOKEN as env var name for token parameter