### PR TITLE
CLI Code Quality Improvements

### DIFF
--- a/src/governance_token_analyzer/cli/main.py
+++ b/src/governance_token_analyzer/cli/main.py
@@ -181,11 +181,11 @@ def analyze(protocol, limit, output_format, output_dir, chart, live_data, simula
         raise click.UsageError(
             "Options --live-data and --simulated-data are mutually exclusive. Please specify only one."
         )
-    
+
     # Set live_data based on simulated_data flag
     if simulated_data:
         live_data = False
-    
+
     try:
         execute_analyze_command(
             protocol=protocol,
@@ -508,7 +508,7 @@ def historical_analysis(protocol, metric, data_dir, output_dir, output_format, p
                 # Extract first and last data points for old and new distribution
                 old_data = pd.DataFrame([trend_data[0]])
                 new_data = pd.DataFrame([trend_data[-1]])
-                
+
                 trend_metrics = calculate_distribution_change(old_data, new_data)
 
                 # Display trend metrics
@@ -659,7 +659,9 @@ def generate_report(protocol, output_format, output_dir, include_historical, dat
                     # Convert to list of dictionaries with date and value
                     historical_data_records = []
                     for date, value in time_series_df.iterrows():
-                        historical_data_records.append({"date": date.strftime("%Y-%m-%d"), "value": float(value.iloc[0])})
+                        historical_data_records.append(
+                            {"date": date.strftime("%Y-%m-%d"), "value": float(value.iloc[0])}
+                        )
                 else:
                     click.echo("⚠️ No historical data found")
             except Exception as e:
@@ -695,11 +697,11 @@ def generate_report(protocol, output_format, output_dir, include_historical, dat
 
 def _extract_token_holders(snapshot_data, idx):
     """Extract token holders from a snapshot or convert balances to token holder format.
-    
+
     Args:
         snapshot_data: The snapshot data dictionary
         idx: Index for generating addresses if needed
-        
+
     Returns:
         List of token holder dictionaries
     """
@@ -707,18 +709,16 @@ def _extract_token_holders(snapshot_data, idx):
         return snapshot_data["token_holders"]
     elif "balances" in snapshot_data:
         # Convert balances to token holders format
-        return [
-            {"address": f"0x{i:040x}", "balance": balance} for i, balance in enumerate(snapshot_data["balances"])
-        ]
+        return [{"address": f"0x{i:040x}", "balance": balance} for i, balance in enumerate(snapshot_data["balances"])]
     return []
 
 
 def _extract_positive_balances(token_holders):
     """Extract positive balances from token holders.
-    
+
     Args:
         token_holders: List of token holder dictionaries
-        
+
     Returns:
         List of positive balance values
     """
@@ -727,13 +727,13 @@ def _extract_positive_balances(token_holders):
 
 def _save_snapshot(snapshot, snapshot_file, date_str, metrics):
     """Save a snapshot to a file and return visualization data.
-    
+
     Args:
         snapshot: The snapshot dictionary to save
         snapshot_file: Path to save the snapshot
         date_str: Date string for the snapshot
         metrics: Metrics dictionary
-        
+
     Returns:
         tuple: (date_str, gini_coefficient) if successful, (None, None) if failed
     """
@@ -748,14 +748,14 @@ def _save_snapshot(snapshot, snapshot_file, date_str, metrics):
 
 def _process_snapshot(i, date_str, snapshot_data, protocol, protocol_dir):
     """Process a single snapshot and save it to disk.
-    
+
     Args:
         i: Snapshot index
         date_str: Date string for the snapshot
         snapshot_data: The snapshot data dictionary
         protocol: Protocol name
         protocol_dir: Directory to save the snapshot file
-        
+
     Returns:
         tuple: (date_str, gini_coefficient) if successful, (None, None) if failed
     """
@@ -764,16 +764,16 @@ def _process_snapshot(i, date_str, snapshot_data, protocol, protocol_dir):
     if not token_holders:
         click.echo(f"  ⚠️ No token holders in snapshot {i + 1}, skipping")
         return None, None
-        
+
     # Extract positive balances
     balances = _extract_positive_balances(token_holders)
     if not balances:
         click.echo(f"  ⚠️ No positive balances in snapshot {i + 1}, skipping")
         return None, None
-        
+
     # Calculate metrics
     metrics = calculate_all_concentration_metrics(balances)
-    
+
     # Create snapshot in the expected format
     snapshot = {
         "timestamp": date_str,
@@ -782,15 +782,15 @@ def _process_snapshot(i, date_str, snapshot_data, protocol, protocol_dir):
         "token_holders": token_holders,
         "metrics": metrics,
     }
-    
+
     # Save snapshot
     snapshot_file = os.path.join(protocol_dir, f"snapshot_{i + 1}.json")
     date, gini = _save_snapshot(snapshot, snapshot_file, date_str, metrics)
-    
+
     if date and gini is not None:
         click.echo(f"  ✓ Saved snapshot {i + 1} with {len(token_holders)} holders and {len(metrics)} metrics")
         return date, gini
-        
+
     return None, None
 
 
@@ -809,7 +809,7 @@ def process_and_save_historical_snapshots(historical_snapshots_dict, protocol, p
     """
     dates = []
     gini_values = []
-    
+
     # Ensure directories exist
     try:
         os.makedirs(protocol_dir, exist_ok=True)

--- a/src/governance_token_analyzer/cli/main.py
+++ b/src/governance_token_analyzer/cli/main.py
@@ -181,7 +181,9 @@ def analyze(protocol, limit, format, output_dir, chart, live_data, simulated_dat
         live_data = False
     # Handle mutually exclusive options
     if live_data and simulated_data:
-        raise click.UsageError("Options --live-data and --simulated-data are mutually exclusive. Please specify only one.")
+        raise click.UsageError(
+            "Options --live-data and --simulated-data are mutually exclusive. Please specify only one."
+        )
     try:
         execute_analyze_command(
             protocol=protocol,
@@ -688,19 +690,19 @@ def generate_report(protocol, format, output_dir, include_historical, data_dir):
 def process_and_save_historical_snapshots(historical_snapshots_dict, protocol, protocol_dir, output_dir):
     """
     Process and save historical snapshots to disk.
-    
+
     Args:
         historical_snapshots_dict: Dictionary of historical snapshots
         protocol: Protocol name
         protocol_dir: Directory to save snapshot files
         output_dir: Directory to save visualization outputs
-        
+
     Returns:
         tuple: Lists of dates and gini values for visualization
     """
     dates = []
     gini_values = []
-    
+
     # Save snapshots in the correct format for HistoricalDataManager
     for i, (date_str, snapshot_data) in enumerate(historical_snapshots_dict.items()):
         # Extract token holders from the snapshot
@@ -710,8 +712,7 @@ def process_and_save_historical_snapshots(historical_snapshots_dict, protocol, p
         elif "balances" in snapshot_data:
             # Convert balances to token holders format
             token_holders = [
-                {"address": f"0x{i:040x}", "balance": balance}
-                for i, balance in enumerate(snapshot_data["balances"])
+                {"address": f"0x{i:040x}", "balance": balance} for i, balance in enumerate(snapshot_data["balances"])
             ]
 
         # Calculate metrics if not present or if token holders are available
@@ -742,14 +743,12 @@ def process_and_save_historical_snapshots(historical_snapshots_dict, protocol, p
                 dates.append(date_str)
                 gini_values.append(metrics.get("gini_coefficient", 0))
 
-                click.echo(
-                    f"  ✓ Saved snapshot {i + 1} with {len(token_holders)} holders and {len(metrics)} metrics"
-                )
+                click.echo(f"  ✓ Saved snapshot {i + 1} with {len(token_holders)} holders and {len(metrics)} metrics")
             else:
                 click.echo(f"  ⚠️ No positive balances in snapshot {i + 1}, skipping")
         else:
             click.echo(f"  ⚠️ No token holders in snapshot {i + 1}, skipping")
-    
+
     return dates, gini_values
 
 
@@ -819,7 +818,7 @@ def simulate_historical(protocol, snapshots, interval, data_dir, output_dir):
             sys.exit(1)
 
         click.echo(f"✅ Generated {len(historical_snapshots_dict)} historical snapshots")
-        
+
         # Process and save snapshots, getting dates and gini values for visualization
         dates, gini_values = process_and_save_historical_snapshots(
             historical_snapshots_dict, protocol, protocol_dir, output_dir

--- a/src/governance_token_analyzer/core/historical_data.py
+++ b/src/governance_token_analyzer/core/historical_data.py
@@ -716,3 +716,29 @@ def simulate_historical_data(
             raise
         logger.error(f"Failed to simulate historical data: {e}")
         raise HistoricalDataError(f"Failed to simulate historical data: {e}") from e
+
+
+def load_historical_snapshots(protocol: str, data_dir: str = "data/historical") -> List[Dict[str, Any]]:
+    """Load historical snapshots for a given protocol.
+    
+    Args:
+        protocol: Name of the protocol
+        data_dir: Directory containing historical data
+        
+    Returns:
+        List of snapshots ordered by timestamp
+        
+    Raises:
+        DataAccessError: If there's an issue accessing the data
+    """
+    try:
+        # Initialize data manager
+        data_manager = HistoricalDataManager(data_dir)
+        
+        # Get snapshots
+        snapshots = data_manager.get_snapshots(protocol)
+        
+        return snapshots
+    except Exception as e:
+        logger.error(f"Failed to load historical snapshots for {protocol}: {e}")
+        return []


### PR DESCRIPTION
## Summary
This PR addresses several code quality issues identified in the CLI module, focusing on improving error handling, fixing option conflicts, and reducing code duplication.

## Changes
1. **Fixed mutually exclusive flags issue**:
   - Added proper error handling for `--live-data` and `--simulated-data` flags
   - Now raises a clear error message when both flags are set instead of silently overriding one

2. **Fixed option conflicts with help flag**:
   - Updated docstring references from `-h` to `-H` for the `--include-historical` option in both the `export-historical-data` and `generate-report` commands
   - This prevents conflicts with Click's built-in help option

3. **Improved code reuse**:
   - Created a helper function `process_and_save_historical_snapshots` to extract duplicated code from the `simulate_historical` function
   - This improves maintainability and reduces the complexity of the command handler

## Testing
- Manually verified that the CLI correctly raises an error when both `--live-data` and `--simulated-data` flags are set
- Confirmed that the `-H` short option works correctly for the `--include-historical` flag
- Verified that the refactored `simulate_historical` command works as expected

## Future Work
This PR addresses the most immediate code quality issues, but there are deeper architectural issues that will be addressed in a separate PR:

1. Reducing nested conditional logic in CLI command handlers
2. Addressing low cohesion by breaking down large functions
3. Reducing complexity depth in functions like `export_historical_data` and `status`
4. Reorganizing the CLI structure to improve maintainability

## Summary by Sourcery

Improve the CLI module by fixing flag conflicts and enhancing error handling, and refactoring repeated code into a reusable helper.

Bug Fixes:
- Enforce mutual exclusivity of --live-data and --simulated-data flags with a clear UsageError.
- Change include-historical short option from -h to -H in export-historical-data and generate-report to avoid help flag conflicts.

Enhancements:
- Extract process_and_save_historical_snapshots helper to remove duplicated logic in simulate-historical command.